### PR TITLE
Bump apex.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@financial-times/n-logger": "^5.0.0",
     "@financial-times/n-raven": "^2.0.0",
-    "apex.js": "^1.1.0",
+    "apex.js": "^2.0.0",
     "aws-sdk": "^2.7.10",
     "denodeify": "^1.2.1",
     "es6-promise": "^3.0.2",


### PR DESCRIPTION
Version 2.x ([release notes](https://github.com/apex/node-apex/blob/master/History.md)) also passes the callback through to the handler.

This is useful in cases where the consumer wishes to wrap this library in a promise, which can be passed to a test framework for the purpose of asserting on the handler, rather than using something like [lambda-tester](https://github.com/vandium-io/lambda-tester).

e.g. 
```js
const nextLambdaWrapper = handler => (event, context, callback) => 
  new Promise((resolve, reject) => {
    nextLambda(handler)(event, context, (error, response) => {
      if (error) {
        reject(error)
      } else {
        resolve(response)
      }
      callback(error, response)
    })
  })
```

*Note: this breaks support for node 0.10.x lambdas*